### PR TITLE
UI: Update Youtube get stream key URL

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -567,7 +567,7 @@ void AutoConfigStreamPage::UpdateKeyLink()
 		streamKeyLink =
 			"https://www.twitch.tv/broadcast/dashboard/streamkey";
 	} else if (serviceName == "YouTube / YouTube Gaming") {
-		streamKeyLink = "https://www.youtube.com/live_dashboard";
+		streamKeyLink = "https://youtube.com/livestreaming";
 		isYoutube = true;
 	} else if (serviceName.startsWith("Restream.io")) {
 		streamKeyLink =

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -242,7 +242,7 @@ void OBSBasicSettings::UpdateKeyLink()
 		streamKeyLink =
 			"https://www.twitch.tv/broadcast/dashboard/streamkey";
 	} else if (serviceName == "YouTube / YouTube Gaming") {
-		streamKeyLink = "https://www.youtube.com/live_dashboard";
+		streamKeyLink = "https://youtube.com/livestreaming";
 	} else if (serviceName.startsWith("Restream.io")) {
 		streamKeyLink =
 			"https://restream.io/settings/streaming-setup?from=OBS";


### PR DESCRIPTION
The old URL is going to be deprecated soon, and this is why we replaced
with a new one.