### PR TITLE
UI: Add Youtube-HLS in stream service dropdown

### DIFF
--- a/UI/window-basic-auto-config.cpp
+++ b/UI/window-basic-auto-config.cpp
@@ -566,7 +566,8 @@ void AutoConfigStreamPage::UpdateKeyLink()
 	if (serviceName == "Twitch") {
 		streamKeyLink =
 			"https://www.twitch.tv/broadcast/dashboard/streamkey";
-	} else if (serviceName == "YouTube / YouTube Gaming") {
+	} else if ((serviceName == "YouTube - RTMP") ||
+		   (serviceName == "YouTube - HLS")) {
 		streamKeyLink = "https://www.youtube.com/live_dashboard";
 		isYoutube = true;
 	} else if (serviceName.startsWith("Restream.io")) {

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -241,7 +241,8 @@ void OBSBasicSettings::UpdateKeyLink()
 	if (serviceName == "Twitch") {
 		streamKeyLink =
 			"https://www.twitch.tv/broadcast/dashboard/streamkey";
-	} else if (serviceName == "YouTube / YouTube Gaming") {
+	} else if ((serviceName == "YouTube - RTMP") ||
+		   (serviceName == "YouTube - HLS")) {
 		streamKeyLink = "https://www.youtube.com/live_dashboard";
 	} else if (serviceName.startsWith("Restream.io")) {
 		streamKeyLink =

--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 133,
+	"version": 134,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 133
+			"version": 134
 		}
 	]
 }


### PR DESCRIPTION
Change the name of Youtube / Youtube Gaming to Youtube-RTMP.
Add an option to the streaming services menu for Youtube-HLS
and provide ingestion link in services.json. Increment the number of versions
in package.json. 