### PR TITLE
rtmp-services: Add Youtube-HLS to service dropdown

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 133,
+	"version": 134,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 133
+			"version": 134
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -198,7 +198,27 @@
             }
         },
         {
-            "name": "YouTube / YouTube Gaming",
+            "name": "YouTube - HLS",
+            "common": true,
+            "servers": [
+                {
+                    "name": "Primary YouTube ingest server",
+                    "url": "https://a.upload.youtube.com/http_upload_hls?cid={stream_key}&copy=0&file=out.m3u8"
+                },
+                {
+                    "name": "Backup YouTube ingest server",
+                    "url": "https://b.upload.youtube.com/http_upload_hls?cid={stream_key}&copy=1&file=out.m3u8"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "output": "ffmpeg_hls_muxer",
+                "max video bitrate": 51000,
+                "max audio bitrate": 160
+            }
+        },
+        {
+            "name": "YouTube - RTMP",
             "common": true,
             "servers": [
                 {
@@ -1401,21 +1421,6 @@
                     "url": "rtmp://73846.livepush.myqcloud.com/live/"
                 }
             ]
-        },
-        {
-            "name": "Mixcloud",
-            "servers": [
-                {
-                    "name": "Default",
-                    "url": "rtmp://rtmp.mixcloud.com/broadcast"
-                }
-            ],
-            "recommended": {
-                "keyint": 2,
-                "max video bitrate": 6000,
-                "max audio bitrate": 320,
-                "x264opts": "scenecut=0"
-            }
         },
         {
             "name": "SermonAudio Cloud",

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -198,6 +198,7 @@
             }
         },
         {
+<<<<<<< HEAD
             "name": "YouTube - HLS",
             "common": true,
             "servers": [
@@ -219,6 +220,9 @@
         },
         {
             "name": "YouTube - RTMP",
+=======
+            "name": "YouTube / YouTube Gaming",
+>>>>>>> 77e099bf... Revert "plugins: Add Youtube-HLS to the Service dropdown"
             "common": true,
             "servers": [
                 {
@@ -1421,6 +1425,21 @@
                     "url": "rtmp://73846.livepush.myqcloud.com/live/"
                 }
             ]
+        }, 
+        {	
+            "name": "Mixcloud",	
+            "servers": [	
+                {	
+                    "name": "Default",	
+                    "url": "rtmp://rtmp.mixcloud.com/broadcast"	
+                }	
+            ],	
+            "recommended": {
+                "keyint": 2,	
+                "max video bitrate": 6000,	
+                "max audio bitrate": 320,	
+                "x264opts": "scenecut=0"	
+            }	
         },
         {
             "name": "SermonAudio Cloud",

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -1421,7 +1421,7 @@
                     "url": "rtmp://73846.livepush.myqcloud.com/live/"
                 }
             ]
-        }, 
+        },
         {
             "name": "Mixcloud",
             "servers": [
@@ -1429,13 +1429,13 @@
                     "name": "Default",
                     "url": "rtmp://rtmp.mixcloud.com/broadcast"
                 }
-            ],	
+            ],
             "recommended": {
-                "keyint": 2,	
-                "max video bitrate": 6000,	
-                "max audio bitrate": 320,	
-                "x264opts": "scenecut=0"	
-            }	
+                "keyint": 2,
+                "max video bitrate": 6000,
+                "max audio bitrate": 320,
+                "x264opts": "scenecut=0"
+            }
         },
         {
             "name": "SermonAudio Cloud",

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -198,7 +198,6 @@
             }
         },
         {
-<<<<<<< HEAD
             "name": "YouTube - HLS",
             "common": true,
             "servers": [
@@ -220,9 +219,6 @@
         },
         {
             "name": "YouTube - RTMP",
-=======
-            "name": "YouTube / YouTube Gaming",
->>>>>>> 77e099bf... Revert "plugins: Add Youtube-HLS to the Service dropdown"
             "common": true,
             "servers": [
                 {
@@ -1426,13 +1422,13 @@
                 }
             ]
         }, 
-        {	
-            "name": "Mixcloud",	
-            "servers": [	
-                {	
-                    "name": "Default",	
-                    "url": "rtmp://rtmp.mixcloud.com/broadcast"	
-                }	
+        {
+            "name": "Mixcloud",
+            "servers": [
+                {
+                    "name": "Default",
+                    "url": "rtmp://rtmp.mixcloud.com/broadcast"
+                }
             ],	
             "recommended": {
                 "keyint": 2,	


### PR DESCRIPTION
Change the name of Youtube / Youtube Gaming to Youtube-RTMP.
Add an option to the streaming services menu for Youtube-HLS
and provide ingestion link in services.json. Increment the
number of versions in package.json.