### PR TITLE
obs-ffmpeg: Add support for HLS ingestion

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -519,29 +519,38 @@ static inline int open_output_file(struct ffmpeg_mux *ffm)
 #define SRT_PROTO "srt"
 #define UDP_PROTO "udp"
 #define TCP_PROTO "tcp"
+#define HTTP_PROTO "http"
 
 static int ffmpeg_mux_init_context(struct ffmpeg_mux *ffm)
 {
 	AVOutputFormat *output_format;
 	int ret;
-	bool isNetwork = false;
+	bool is_network = false;
+	bool is_http = false;
+	is_http = (strncmp(ffm->params.file, HTTP_PROTO,
+			   sizeof(HTTP_PROTO) - 1) == 0);
+
 	if (strncmp(ffm->params.file, SRT_PROTO, sizeof(SRT_PROTO) - 1) == 0 ||
 	    strncmp(ffm->params.file, UDP_PROTO, sizeof(UDP_PROTO) - 1) == 0 ||
-	    strncmp(ffm->params.file, TCP_PROTO, sizeof(TCP_PROTO) - 1) == 0)
-		isNetwork = true;
-
-	if (isNetwork) {
+	    strncmp(ffm->params.file, TCP_PROTO, sizeof(TCP_PROTO) - 1) == 0 ||
+	    is_http) {
+		is_network = true;
 		avformat_network_init();
-		output_format = av_guess_format("mpegts", NULL, "video/M2PT");
-	} else {
-		output_format = av_guess_format(NULL, ffm->params.file, NULL);
 	}
+
+	if (is_network && !is_http)
+		output_format = av_guess_format("mpegts", NULL, "video/M2PT");
+	else
+		output_format = av_guess_format(NULL, ffm->params.file, NULL);
 
 	if (output_format == NULL) {
 		fprintf(stderr, "Couldn't find an appropriate muxer for '%s'\n",
 			ffm->params.file);
 		return FFM_ERROR;
 	}
+	printf("info: output_format name and long_name: %s, %s\n",
+	       output_format->name ? output_format->name : "unknown",
+	       output_format->long_name ? output_format->long_name : "unknown");
 
 	ret = avformat_alloc_output_context2(&ffm->output, output_format, NULL,
 					     NULL);

--- a/plugins/obs-ffmpeg/obs-ffmpeg.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg.c
@@ -24,6 +24,7 @@ extern struct obs_output_info ffmpeg_output;
 extern struct obs_output_info ffmpeg_muxer;
 extern struct obs_output_info ffmpeg_mpegts_muxer;
 extern struct obs_output_info replay_buffer;
+extern struct obs_output_info ffmpeg_hls_muxer;
 extern struct obs_encoder_info aac_encoder_info;
 extern struct obs_encoder_info opus_encoder_info;
 extern struct obs_encoder_info nvenc_encoder_info;
@@ -231,6 +232,7 @@ bool obs_module_load(void)
 	obs_register_output(&ffmpeg_output);
 	obs_register_output(&ffmpeg_muxer);
 	obs_register_output(&ffmpeg_mpegts_muxer);
+	obs_register_output(&ffmpeg_hls_muxer);
 	obs_register_output(&replay_buffer);
 	obs_register_encoder(&aac_encoder_info);
 	obs_register_encoder(&opus_encoder_info);


### PR DESCRIPTION
Add and register an obs_output_info struct called
ffmpeg_hls_muxer, and initialize the struct with its
own start function. Within this start function, set a
user-agent setting so that the underlying HTTP request
made by ffmpeg will have a User-Agent header. Determine
whether the stream is hls to guess the output format in
ffmpeg-mux/ffmpeg-mux.c.