### PR TITLE
Fix http user catting wip

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -388,7 +388,7 @@ static bool ffmpeg_hls_mux_start(void *data)
 	stream_key = obs_service_get_key(service);
 	dstr_copy(&path, path_str);
 	dstr_replace(&path, "{stream_key}", stream_key);
-	if dstr_is_empty (stream->muxer_settings)
+	if (dstr_is_empty(&stream->muxer_settings))
 		dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s",
 			  OBS_VERSION);
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -388,8 +388,9 @@ static bool ffmpeg_hls_mux_start(void *data)
 	stream_key = obs_service_get_key(service);
 	dstr_copy(&path, path_str);
 	dstr_replace(&path, "{stream_key}", stream_key);
-	dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s",
-		  OBS_VERSION);
+	if dstr_is_empty (stream->muxer_settings)
+		dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s",
+			  OBS_VERSION);
 
 	start_pipe(stream, path.array);
 	dstr_free(&path);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -388,9 +388,9 @@ static bool ffmpeg_hls_mux_start(void *data)
 	stream_key = obs_service_get_key(service);
 	dstr_copy(&path, path_str);
 	dstr_replace(&path, "{stream_key}", stream_key);
-	if (dstr_is_empty(&stream->muxer_settings))
-		dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s",
-			  OBS_VERSION);
+	dstr_init(&stream->muxer_settings);
+	dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s",
+		  OBS_VERSION);
 
 	start_pipe(stream, path.array);
 	dstr_free(&path);


### PR DESCRIPTION
Discovered a small bug after many rounds of testing and reading the log. Because we are using dstr_catf to copy the libobs and OBS version to http_user_agent, it was catting this string onto muxer_settings every single time the hls_start_function runs. I added a check to ensure that this is not set unless muxer_settings is already empty. 