### PR TITLE
obs-ffmpeg: Add muxer settings

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -548,7 +548,7 @@ static int ffmpeg_mux_init_context(struct ffmpeg_mux *ffm)
 			ffm->params.file);
 		return FFM_ERROR;
 	}
-	printf("info: Output_format name and long_name: %s, %s\n",
+	printf("info: Output format name and long_name: %s, %s\n",
 	       output_format->name ? output_format->name : "unknown",
 	       output_format->long_name ? output_format->long_name : "unknown");
 

--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -548,7 +548,7 @@ static int ffmpeg_mux_init_context(struct ffmpeg_mux *ffm)
 			ffm->params.file);
 		return FFM_ERROR;
 	}
-	printf("info: output_format name and long_name: %s, %s\n",
+	printf("info: Output_format name and long_name: %s, %s\n",
 	       output_format->name ? output_format->name : "unknown",
 	       output_format->long_name ? output_format->long_name : "unknown");
 

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -389,7 +389,8 @@ static bool ffmpeg_hls_mux_start(void *data)
 	dstr_copy(&path, path_str);
 	dstr_replace(&path, "{stream_key}", stream_key);
 	dstr_init(&stream->muxer_settings);
-	dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s method=PUT http_persistent=1",
+	dstr_catf(&stream->muxer_settings,
+		  "http_user_agent=libobs/%s method=PUT http_persistent=1",
 		  OBS_VERSION);
 
 	start_pipe(stream, path.array);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -389,7 +389,7 @@ static bool ffmpeg_hls_mux_start(void *data)
 	dstr_copy(&path, path_str);
 	dstr_replace(&path, "{stream_key}", stream_key);
 	dstr_init(&stream->muxer_settings);
-	dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s",
+	dstr_catf(&stream->muxer_settings, "http_user_agent=libobs/%s method=PUT http_persistent=1",
 		  OBS_VERSION);
 
 	start_pipe(stream, path.array);


### PR DESCRIPTION
Add a method=PUT and http_persistent=1 to the muxer_settings
so as to circumvent the warning "no HTTP method set" and
specify a persistent connection. In ffmpeg-mux.c, change
capitalization of log statement to be more consistent with
others.