### PR TITLE
UI: Add "More Info" Button to OBS Basic Stream Settings

### DIFF
--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -119,7 +119,7 @@
      <item>
       <widget class="QStackedWidget" name="settingsPages">
        <property name="currentIndex">
-        <number>1</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="generalPage">
         <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>810</width>
-              <height>1087</height>
+              <width>803</width>
+              <height>1026</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -1088,12 +1088,6 @@
                 </item>
                 <item>
                  <widget class="UrlPushButton" name="getStreamKeyButton">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
                   <property name="toolTip">
                    <string/>
                   </property>
@@ -1300,8 +1294,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>740</width>
-              <height>767</height>
+              <width>603</width>
+              <height>631</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -2432,7 +2426,7 @@
                                  <rect>
                                   <x>9</x>
                                   <y>0</y>
-                                  <width>250</width>
+                                  <width>236</width>
                                   <height>25</height>
                                  </rect>
                                 </property>
@@ -3795,8 +3789,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>691</width>
-              <height>601</height>
+              <width>555</width>
+              <height>469</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -4651,8 +4645,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>755</width>
-              <height>930</height>
+              <width>596</width>
+              <height>781</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -119,7 +119,7 @@
      <item>
       <widget class="QStackedWidget" name="settingsPages">
        <property name="currentIndex">
-        <number>0</number>
+        <number>1</number>
        </property>
        <widget class="QWidget" name="generalPage">
         <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -151,8 +151,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>803</width>
-              <height>1026</height>
+              <width>810</width>
+              <height>1087</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_19">
@@ -824,37 +824,43 @@
              </widget>
             </item>
             <item row="3" column="1">
-       <widget class="QWidget" name="serviceWidget" native="true">
-        <layout class="QHBoxLayout" name="serviceWidgetLayout">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QComboBox" name="service">
-           <property name="maxVisibleItems">
-             <number>20</number>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="UrlPushButton" name="moreInfoButton">
-           <property name="text">
-            <string>Basic.AutoConfig.StreamPage.MoreInfo</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-       </item>
+             <widget class="QWidget" name="serviceWidget" native="true">
+              <layout class="QHBoxLayout" name="serviceWidgetLayout" stretch="0,0">
+               <property name="leftMargin">
+                <number>0</number>
+               </property>
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <property name="rightMargin">
+                <number>0</number>
+               </property>
+               <property name="bottomMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QComboBox" name="service">
+                 <property name="maxVisibleItems">
+                  <number>20</number>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="UrlPushButton" name="moreInfoButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Basic.AutoConfig.StreamPage.MoreInfo</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
             <item row="1" column="0">
              <spacer name="horizontalSpacer_17">
               <property name="orientation">
@@ -1082,6 +1088,12 @@
                 </item>
                 <item>
                  <widget class="UrlPushButton" name="getStreamKeyButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
                   <property name="toolTip">
                    <string/>
                   </property>
@@ -1288,8 +1300,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>603</width>
-              <height>631</height>
+              <width>740</width>
+              <height>767</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -2420,7 +2432,7 @@
                                  <rect>
                                   <x>9</x>
                                   <y>0</y>
-                                  <width>236</width>
+                                  <width>250</width>
                                   <height>25</height>
                                  </rect>
                                 </property>
@@ -3783,8 +3795,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>555</width>
-              <height>469</height>
+              <width>691</width>
+              <height>601</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_50">
@@ -4639,8 +4651,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>596</width>
-              <height>781</height>
+              <width>755</width>
+              <height>930</height>
              </rect>
             </property>
             <layout class="QVBoxLayout" name="verticalLayout_23">

--- a/UI/forms/OBSBasicSettings.ui
+++ b/UI/forms/OBSBasicSettings.ui
@@ -824,12 +824,37 @@
              </widget>
             </item>
             <item row="3" column="1">
-             <widget class="QComboBox" name="service">
-              <property name="maxVisibleItems">
-               <number>20</number>
-              </property>
-             </widget>
-            </item>
+       <widget class="QWidget" name="serviceWidget" native="true">
+        <layout class="QHBoxLayout" name="serviceWidgetLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QComboBox" name="service">
+           <property name="maxVisibleItems">
+             <number>20</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="UrlPushButton" name="moreInfoButton">
+           <property name="text">
+            <string>Basic.AutoConfig.StreamPage.MoreInfo</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       </item>
             <item row="1" column="0">
              <spacer name="horizontalSpacer_17">
               <property name="orientation">

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -232,7 +232,7 @@ void OBSBasicSettings::SaveStream1Settings()
 		main->auth->LoadUI();
 }
 
-void AutoConfigStreamPage::UpdateMoreInfoLink()
+void OBSBasicSettings::UpdateMoreInfoLink()
 {
 	if (IsCustomService()) {
 		ui->moreInfoButton->hide();

--- a/UI/window-basic-settings-stream.cpp
+++ b/UI/window-basic-settings-stream.cpp
@@ -78,6 +78,8 @@ void OBSBasicSettings::InitStreamPage()
 		SLOT(UpdateServerList()));
 	connect(ui->service, SIGNAL(currentIndexChanged(int)), this,
 		SLOT(UpdateKeyLink()));
+	connect(ui->service, SIGNAL(currentIndexChanged(int)), this,
+		SLOT(UpdateMoreInfoLink()));
 }
 
 void OBSBasicSettings::LoadStream1Settings()
@@ -144,6 +146,7 @@ void OBSBasicSettings::LoadStream1Settings()
 	obs_data_release(settings);
 
 	UpdateKeyLink();
+	UpdateMoreInfoLink();
 
 	bool streamActive = obs_frontend_streaming_active();
 	ui->streamPage->setEnabled(!streamActive);
@@ -229,6 +232,35 @@ void OBSBasicSettings::SaveStream1Settings()
 		main->auth->LoadUI();
 }
 
+void AutoConfigStreamPage::UpdateMoreInfoLink()
+{
+	if (IsCustomService()) {
+		ui->moreInfoButton->hide();
+		return;
+	}
+
+	QString serviceName = ui->service->currentText();
+	obs_properties_t *props = obs_get_service_properties("rtmp_common");
+	obs_property_t *services = obs_properties_get(props, "service");
+
+	OBSData settings = obs_data_create();
+	obs_data_release(settings);
+
+	obs_data_set_string(settings, "service", QT_TO_UTF8(serviceName));
+	obs_property_modified(services, settings);
+
+	const char *more_info_link =
+		obs_data_get_string(settings, "more_info_link");
+
+	if (!more_info_link || (*more_info_link == '\0')) {
+		ui->moreInfoButton->hide();
+	} else {
+		ui->moreInfoButton->setTargetUrl(QUrl(more_info_link));
+		ui->moreInfoButton->show();
+	}
+	obs_properties_destroy(props);
+}
+
 void OBSBasicSettings::UpdateKeyLink()
 {
 	if (IsCustomService()) {
@@ -241,8 +273,7 @@ void OBSBasicSettings::UpdateKeyLink()
 	if (serviceName == "Twitch") {
 		streamKeyLink =
 			"https://www.twitch.tv/broadcast/dashboard/streamkey";
-	} else if ((serviceName == "YouTube - RTMP") ||
-		   (serviceName == "YouTube - HLS")) {
+	} else if (serviceName.startsWith("YouTube")) {
 		streamKeyLink = "https://www.youtube.com/live_dashboard";
 	} else if (serviceName.startsWith("Restream.io")) {
 		streamKeyLink =

--- a/UI/window-basic-settings.hpp
+++ b/UI/window-basic-settings.hpp
@@ -239,6 +239,7 @@ private:
 private slots:
 	void UpdateServerList();
 	void UpdateKeyLink();
+	void UpdateMoreInfoLink();
 	void on_show_clicked();
 	void on_authPwShow_clicked();
 	void on_connectAccount_clicked();

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -200,7 +200,7 @@
         {
             "name": "YouTube - HLS",
             "common": false,
-            "more_info_link": "https://www.youtube.com/live_dashboard",
+            "more_info_link": "https://developers.google.com/youtube/v3/live/guides/ingestion-protocol-comparison",
             "servers": [
                 {
                     "name": "Primary YouTube ingest server",


### PR DESCRIPTION
Add "More Info" Button to OBS Basic Stream Settings by doing the following:

- Add UpdateMoreInfoLink function to window-basic-settings-stream.cpp
- Add slots and signals to trigger calling of UpdateMoreInfoLink 
when a service is selected from the dropdown
- Include UpdateMoreInfoLink function in the window-basic-settings.hpp file
to make it available to the class
- Add the button itself to the stream settings UI and set its size policy 
to maximum to ensure that it doesn't expand when the window does
- Test manually to make sure everything works as expected
- Ran clang-format on all c and cpp files 
