### PR TITLE
obs-ffmpeg: Add hls_time as a muxer_setting

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -375,6 +375,9 @@ static bool ffmpeg_hls_mux_start(void *data)
 	const char *path_str;
 	const char *stream_key;
 	struct dstr path = {0};
+	obs_encoder_t *vencoder;
+	obs_data_t *settings; 
+	int keyint_sec; 
 
 	if (!obs_output_can_begin_data_capture(stream->output, 0))
 		return false;
@@ -392,6 +395,13 @@ static bool ffmpeg_hls_mux_start(void *data)
 	dstr_catf(&stream->muxer_settings,
 		  "http_user_agent=libobs/%s method=PUT http_persistent=1",
 		  OBS_VERSION);
+
+	vencoder = obs_output_get_video_encoder(stream->output);
+	settings = obs_encoder_get_settings(vencoder);
+	keyint_sec = obs_data_get_int(settings, "keyint_sec");
+	if (keyint_sec)
+		printf("Maya's log: keyint_sec is %d", keyint_sec);
+		dstr_catf(&stream->muxer_settings, " hls_time=%d", keyint_sec);
 
 	start_pipe(stream, path.array);
 	dstr_free(&path);

--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -376,8 +376,8 @@ static bool ffmpeg_hls_mux_start(void *data)
 	const char *stream_key;
 	struct dstr path = {0};
 	obs_encoder_t *vencoder;
-	obs_data_t *settings; 
-	int keyint_sec; 
+	obs_data_t *settings;
+	int keyint_sec;
 
 	if (!obs_output_can_begin_data_capture(stream->output, 0))
 		return false;
@@ -400,8 +400,9 @@ static bool ffmpeg_hls_mux_start(void *data)
 	settings = obs_encoder_get_settings(vencoder);
 	keyint_sec = obs_data_get_int(settings, "keyint_sec");
 	if (keyint_sec)
-		printf("Maya's log: keyint_sec is %d", keyint_sec);
 		dstr_catf(&stream->muxer_settings, " hls_time=%d", keyint_sec);
+
+	obs_data_release(settings);
 
 	start_pipe(stream, path.array);
 	dstr_free(&path);


### PR DESCRIPTION
Add hls_time as a muxer_setting for hls ingestion by:
- setting hls_time to keyint_sec, the key frame interval
- obtaining the value keyint_sec from video encoder settings
- later releasing settings to avoid memory leaks,,