### PR TITLE
obs-ffmpeg: Add ignore_io_errors option

### DIFF
--- a/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/obs-ffmpeg-mux.c
@@ -394,6 +394,7 @@ static bool ffmpeg_hls_mux_start(void *data)
 	dstr_catf(&stream->muxer_settings,
 		  "http_user_agent=libobs/%s method=PUT http_persistent=1",
 		  OBS_VERSION);
+	dstr_catf(&stream->muxer_settings, " ignore_io_errors=1");
 
 	vencoder = obs_output_get_video_encoder(stream->output);
 	settings = obs_encoder_get_settings(vencoder);


### PR DESCRIPTION
Add ignore_io_errors option for ffmpeg, because otherwise,
if a single segment or playlist upload fails, ffmpeg may
kill the stream as a whole rather than simply dropping the
segment/playlist. Also ran clang-format.