### PR TITLE
obs-ffmpeg: Add YouTube RTMPS service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 140,
+	"version": 141,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 140
+			"version": 141
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -217,6 +217,25 @@
             }
         },
         {
+            "name": "YouTube - RTMPS",
+            "common": true,
+            "servers": [
+                {
+                    "name": "Primary YouTube ingest server",
+                    "url": "rtmps://a.rtmps.youtube.com:443/live2"
+                },
+                {
+                    "name": "Backup YouTube ingest server",
+                    "url": "rtmps://b.rtmps.youtube.com:443/live2"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 51000,
+                "max audio bitrate": 160
+            }
+        },
+        {
             "name": "VIMM",
             "servers": [
                 {


### PR DESCRIPTION
Add YouTube RTMPS service to the services.json file.
Include primary and backup ingestion url. 