### PR TITLE
obs-ffmpeg: Set codec->time_base

### DIFF
--- a/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
+++ b/plugins/obs-ffmpeg/ffmpeg-mux/ffmpeg-mux.c
@@ -384,6 +384,8 @@ static void create_video_stream(struct ffmpeg_mux *ffm)
 		(AVRational){ffm->params.fps_den, ffm->params.fps_num};
 
 	ffm->video_stream->time_base = context->time_base;
+	// codec->time_base may still be used if LIBAVFORMAT_VERSION_MAJOR < 59
+	ffm->video_stream->codec->time_base = context->time_base;
 	ffm->video_stream->avg_frame_rate = av_inv_q(context->time_base);
 
 	if (ffm->output->oformat->flags & AVFMT_GLOBALHEADER)


### PR DESCRIPTION
Set codec->time_base because it may still be used if
LIBAVFORMAT_VERSION_MAJOR < 59.