### PR TITLE
rtmp-services: Add YouTube RTMPS service

### DIFF
--- a/plugins/rtmp-services/data/package.json
+++ b/plugins/rtmp-services/data/package.json
@@ -1,10 +1,10 @@
 {
 	"url": "https://obsproject.com/obs2_update/rtmp-services",
-	"version": 145,
+	"version": 146,
 	"files": [
 		{
 			"name": "services.json",
-			"version": 145
+			"version": 146
 		}
 	]
 }

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -217,6 +217,25 @@
             }
         },
         {
+            "name": "YouTube - RTMPS / RTMP Encrypted (beta)",
+            "common": true,
+            "servers": [
+                {
+                    "name": "Primary YouTube ingest server",
+                    "url": "rtmp://a.rtmp.youtube.com/live2"
+                },
+                {
+                    "name": "Backup YouTube ingest server",
+                    "url": "rtmps://b.rtmps.youtube.com:443/live2"
+                }
+            ],
+            "recommended": {
+                "keyint": 2,
+                "max video bitrate": 51000,
+                "max audio bitrate": 160
+            }
+        },
+        {
             "name": "VIMM",
             "servers": [
                 {

--- a/plugins/rtmp-services/data/services.json
+++ b/plugins/rtmp-services/data/services.json
@@ -222,7 +222,7 @@
             "servers": [
                 {
                     "name": "Primary YouTube ingest server",
-                    "url": "rtmp://a.rtmp.youtube.com/live2"
+                    "url": "rtmps://a.rtmps.youtube.com:443/live2"
                 },
                 {
                     "name": "Backup YouTube ingest server",


### PR DESCRIPTION
Add YouTube RTMPS service to the services.json file, specifying both primary
and secondary ingestion URLs. Increment the version number to 146. 